### PR TITLE
Open profile links from the home page in new tabs

### DIFF
--- a/_includes/home-network-links.html
+++ b/_includes/home-network-links.html
@@ -1,7 +1,7 @@
 <!-- Used by theme-home-builtin-1,2,3 -->
 
 {% for profile in site.data.bio.basics.profiles %}
-   <a href="{{ profile.url }}"> <i class="big {{ profile.network | downcase }} icon icon-color"></i> </a>
+   <a target="_blank" href="{{ profile.url }}"> <i class="big {{ profile.network | downcase }} icon icon-color"></i> </a>
 {% endfor %}
 
 {% if site.data.bio.basics.email %}


### PR DESCRIPTION
Opening external profile links in new tabs keeps the rest of the user's TechFolio content on top and not buried in the browser history if a recruiter, for instance, starts diving into a LinkedIn profile.