### PR TITLE
Center home page bio summary

### DIFF
--- a/_includes/theme-home-builtin-1.html
+++ b/_includes/theme-home-builtin-1.html
@@ -21,7 +21,7 @@
         <div class="meta">
           <span class="date">{{ site.data.bio.basics.label }}</span>
         </div>
-        <div class="left aligned description">
+        <div class="center aligned description">
           {{ site.data.bio.basics.summary }}
         </div>
       </div>


### PR DESCRIPTION
I'm not sure if the bio summary was intentionally left aligned but I think it should be centered with the rest of the content, for me at least it looks nicer and fits better with the pages

I have made this change live at https://rosshiga.com/

This is what it looked like previously

![oldsite](https://user-images.githubusercontent.com/10620238/45331864-d902b800-b508-11e8-81bc-41b575fc5596.png)
