### PR TITLE
Remove unnecessary whitespace

### DIFF
--- a/css/print-default.scss
+++ b/css/print-default.scss
@@ -11,7 +11,6 @@
 
 // Make text smaller, remove spacing between list items when printing.
 @media print {
-
   p, a, li {
     font-size: 12px;
   }


### PR DESCRIPTION
This small commit removes an unnecessary whitespace from the print SCSS file